### PR TITLE
Add Surname Generator to Writing Assistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ Dave Pitt
 * [Cliche Finder](http://cliche.theinfo.org/) - Finds cliches in your writing. <img src="Assets\cloud.png" width = 15 alt="Cloud Logo">
 * [Grammarly](https://www.grammarly.com/) - Writing assistant tool which reviews spelling, grammar and tone. <img src="Assets\cloud.png" width = 15 alt="Cloud Logo">
 * [Hemingway App](https://hemingwayapp.com/) - Desktop and online app which helps with readability of text. <img src="Assets\cloud.png" width = 15 alt="Cloud Logo">
+* [Surname Generator](https://surname-generator.com) - Generates realistic last names by origin (29 cultures including English, Japanese, Russian, Brazilian, Nigerian) plus fantasy, D&D and sci-fi flavors — useful for naming characters across stories. <img src="Assets\cloud.png" width = 15 alt="Cloud Logo">


### PR DESCRIPTION
Adds Surname Generator (https://surname-generator.com) to the Writing Assistance section, alongside Cliche Finder and Hemingway App. Same idea — a tool that helps fiction writers.

It's a free in-browser surname generator covering 29 cultures (English, Japanese, Russian, Brazilian, Nigerian, Korean, Italian, Spanish, French, German, Irish, Scottish, Polish, Dutch, Swedish, Greek, Turkish, Arabic, Hebrew, Vietnamese, Filipino, Indian + more) plus dedicated fantasy, D&D (split by race), sci-fi, and "with meanings" generators. Ethnicity pools come from real census/registry frequency lists. Generates 1, 10 or 50 at once with a Copy List button.

No signup, no payment. Happy to move it into a new "Names & Characters" section instead if you'd rather give name-related tools their own home.